### PR TITLE
fixed to work with documented example and run on windows.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -111,6 +111,15 @@ portfolio/
 The next time the very same URL is loaded, and unless `test.jpg` has changed in
 the meantime, the `test.png` is just served and not recreated again.
 
+##  Crop to Fit
+
+Thumbnails will maintain their aspect ratio. In order to make crop the image to fit a specific thumbnail size, append -crop to the format.
+For example, for following will create a square thumbnail with edges cropped off.
+
+```
+<img src='public/thumbnails/200x200-crop/content/some_gallery/test.png?original_extension=jpg' />
+```
+
 ## Contributing to sinatra-thumbnails 
 
 Fell free to fork and submit pull requests. 

--- a/README.mdown
+++ b/README.mdown
@@ -47,6 +47,11 @@ helpers do
   include ContentHelpers
 end
 
+get "/content/*" do
+ file = "content/" + params[:splat].first
+ send_file file
+end
+
 get "/:gallery" do
   # A gallery has markdown description snippet 
   #

--- a/lib/sinatra/thumbnails.rb
+++ b/lib/sinatra/thumbnails.rb
@@ -48,11 +48,11 @@ module Sinatra
 
     def self.convert(src, dest, format)
       if (format =~ /(.*)-crop$/) 
-        #if (im_version <=> [6,6,4]) >= 0
+        if (im_version <=> [6,6,4]) >= 0
           format = "\"" + $1 + "^\"" + " -gravity center -extent " + $1
-        #else
-        #  format = $1
-        #end
+        else
+          format = $1
+        end
       end
       FileUtils.mkdir_p(File.dirname(dest))
       command = "#{Sinatra::Thumbnails.settings.convert_executable} -define jpeg:size=400x400 \"#{src}\" -thumbnail #{format} \"#{dest}\""

--- a/lib/sinatra/thumbnails.rb
+++ b/lib/sinatra/thumbnails.rb
@@ -48,15 +48,15 @@ module Sinatra
 
     def self.convert(src, dest, format)
       if (format =~ /(.*)-crop$/) 
-        if (im_version <=> [6,6,4]) >= 0
-          format = $1 + "^" + " -gravity center -extent " + $1
-        else
-          format = $1
-        end
+        #if (im_version <=> [6,6,4]) >= 0
+          format = "\"" + $1 + "^\"" + " -gravity center -extent " + $1
+        #else
+        #  format = $1
+        #end
       end
       FileUtils.mkdir_p(File.dirname(dest))
       command = "#{Sinatra::Thumbnails.settings.convert_executable} -define jpeg:size=400x400 \"#{src}\" -thumbnail #{format} \"#{dest}\""
-      # puts "Sinatra::Thumbnails: issuing \"#{command}\""
+      puts "Sinatra::Thumbnails: issuing \"#{command}\""
       run_command(command)
     end
     

--- a/lib/sinatra/thumbnails.rb
+++ b/lib/sinatra/thumbnails.rb
@@ -55,7 +55,7 @@ module Sinatra
         end
       end
       FileUtils.mkdir_p(File.dirname(dest))
-      command = "#{Sinatra::Thumbnails.settings.convert_executable} -define jpeg:size=400x400 '#{src}' -thumbnail #{format} '#{dest}'"
+      command = "#{Sinatra::Thumbnails.settings.convert_executable} -define jpeg:size=400x400 \"#{src}\" -thumbnail #{format} \"#{dest}\""
       # puts "Sinatra::Thumbnails: issuing \"#{command}\""
       run_command(command)
     end
@@ -63,7 +63,7 @@ module Sinatra
     def self.ffmpeg(src, dest, format)
       puts "making movie thumb on the fly"
       seconds = (src =~ /\.ss([\d]+)/) ? Regexp.last_match(1).to_i : 0 
-      command = "#{Sinatra::Thumbnails.settings.ffmpeg_executable} -y -i '#{src}' -an -ss #{seconds} -r 1 -vframes 1 -f mjpeg  '#{dest}'"
+      command = "#{Sinatra::Thumbnails.settings.ffmpeg_executable} -y -i \"#{src}\" -an -ss #{seconds} -r 1 -vframes 1 -f mjpeg  \"#{dest}\""
       # puts "Sinatra::Thumbnails: issuing \"#{command}\""
       run_command(command)
       convert(dest, dest, format)
@@ -79,7 +79,7 @@ module Sinatra
       @@settings ||= { :convert_executable  => 'convert'     ,   
                        :ffmpeg_executable   => 'ffmpeg'      ,   
                        :thumbnail_path      => 'public/thumbnails'  ,
-                       :image_path_prefix   => 'public'             ,
+                       :image_path_prefix   => ''             ,
                        :thumbnail_extension => 'png'         ,   
                        :thumbnail_format    => '100x100'       }.extend(Thumbnails::Settings) 
     end

--- a/spec/sinatra-thumbnails_spec.rb
+++ b/spec/sinatra-thumbnails_spec.rb
@@ -14,9 +14,9 @@ module FixtureHelper
   def create_fixtures
     FileUtils.mkdir_p(fixtures_path)
     Sinatra::Base.set :root, fixtures_path
-    Sinatra::Base.set :public, File.join(fixtures_path, "public")
+    Sinatra::Base.set :public_folder, File.join(fixtures_path, "public")
 
-    images_dir = File.join(Sinatra::Base.public,"images")
+    images_dir = File.join(fixtures_path,"images")
     FileUtils.mkdir_p(images_dir)
 
     some_images_dir = File.join(File.dirname(__FILE__), "test_assets") 


### PR DESCRIPTION
The example application in the README didn't work when I tried. Part of the library was look for galleries in  /content another part was looking for them in  /public/content.  This created strange behavior

I think this may have been a bug, or an error in the documentation.
Updated library, tests, and README

Few changes to work on Windows.   Please test on Mac/Linux before accepting pull request

Please provide feedback. This my first pull request and contribution to someone elses project.
